### PR TITLE
Fix handling of onEnd event

### DIFF
--- a/src/Swipe.elm
+++ b/src/Swipe.elm
@@ -278,4 +278,4 @@ onEnd =
 onEndWithOptions : { stopPropagation : Bool, preventDefault : Bool } -> (Event -> msg) -> Html.Attribute msg
 onEndWithOptions options tagger =
     custom "touchend" <|
-        decodeTouchWithOptions "changedTouches" options (Touch Move >> tagger)
+        decodeTouchWithOptions "changedTouches" options (Touch End >> tagger)


### PR DESCRIPTION
Currently, swipes do not work since when ending a swipe action, the resulting event is always a `Moved` gesture, never a `EndGesture` gesture.